### PR TITLE
tweak offset fix

### DIFF
--- a/addon/components/pop-over/component.js
+++ b/addon/components/pop-over/component.js
@@ -285,7 +285,7 @@ export default Component.extend({
     $checkElements.each(function() {
       if (
         jQuery(this).css("position") === "static" &&
-        (jQuery(this).offset().top > 0 || jQuery(this).offset().left > 0)
+        (jQuery(this).offset().top > 0 && jQuery(this).offset().left > 0)
       ) {
         staticElement = this;
         return false;


### PR DESCRIPTION
I can't quite explain why the [fix](https://github.com/CondeNast/ember-pop-over/pull/1) that previously made the popover render right in Copilot modals no longer does so. But this makes it better, which is good enough until we find a real-real fix.